### PR TITLE
Explicit errors

### DIFF
--- a/lib/statesmin/exceptions.rb
+++ b/lib/statesmin/exceptions.rb
@@ -5,4 +5,17 @@ module Statesmin
   class GuardFailedError < StandardError; end
   class TransitionFailedError < StandardError; end
   class TransitionConflictError < StandardError; end
+
+  class NotImplementedError < StandardError
+    def initialize(method_name, transition_class_name)
+      super(_message(method_name, transition_class_name))
+    end
+
+    private
+
+    def _message(method_name, transition_class_name)
+      "'#{method_name}' method is not defined in '#{transition_class_name}'." \
+      "Either define this method or do not include 'TransitionHelper'."
+    end
+  end
 end

--- a/lib/statesmin/transition_helper.rb
+++ b/lib/statesmin/transition_helper.rb
@@ -1,3 +1,5 @@
+require_relative "exceptions"
+
 module Statesmin
   module TransitionHelper
     # Methods to delegate to `state_machine`
@@ -30,13 +32,11 @@ module Statesmin
     private
 
     def state_machine
-      raise "'state_machine' method is not defined in '#{self.class.name}'." \
-            "Either define this method or do not include 'TransitionHelper'."
+      raise Statesmin::NotImplementedError.new('state_machine', self.class.name)
     end
 
     def raise_transition_not_defined_error
-      raise "'transition' method is not defined in '#{self.class.name}'." \
-            "Either define this method or do not include 'TransitionHelper'."
+      raise Statesmin::NotImplementedError.new('transition', self.class.name)
     end
 
     def guard_transitions_to_invalid_states!(next_state)

--- a/spec/statesmin/transition_helper_spec.rb
+++ b/spec/statesmin/transition_helper_spec.rb
@@ -15,9 +15,9 @@ describe Statesmin::TransitionHelper do
 
       Statesmin::TransitionHelper::DELEGATED_METHODS.each do |method_name|
         describe "##{method_name}" do
-          it 'raises a RuntimeError' do
+          it 'raises a NotImplementedError' do
             expect { unimplemented_instance.send(method_name) }.
-              to raise_error(RuntimeError)
+              to raise_error(Statesmin::NotImplementedError)
           end
         end
       end
@@ -37,8 +37,9 @@ describe Statesmin::TransitionHelper do
 
   shared_examples 'a transition method' do |method|
     context 'when no transition method is defined' do
-      it 'raises a RuntimeError' do
-        expect { instance.send(method, :next) }.to raise_error(RuntimeError)
+      it 'raises a NotImplementedError' do
+        expect { instance.send(method, :next) }.
+          to raise_error(Statesmin::NotImplementedError)
       end
     end
 
@@ -108,8 +109,8 @@ describe Statesmin::TransitionHelper do
           allow(state_machine).to receive(:current_state).and_return('new')
         end
 
-        it 'raises an error' do
-          expect { instance.transition_to!(:next) }.to raise_error
+        it 'raises a RuntimeError' do
+          expect { instance.transition_to!(:next) }.to raise_error(RuntimeError)
         end
       end
     end


### PR DESCRIPTION
Use an explicit NotImplementedError when necessary parts of a transition class (one that includes TransitionHelper) are not implemented.
