### PR TITLE
Update transitions

### DIFF
--- a/lib/statesmin/machine.rb
+++ b/lib/statesmin/machine.rb
@@ -200,7 +200,7 @@ module Statesmin
       false
     end
 
-    def transition_to!(new_state, metadata = {})
+    def transition_to!(new_state, metadata = {}, &block)
       initial_state = current_state
       new_state = new_state.to_s
 
@@ -208,8 +208,10 @@ module Statesmin
                           to: new_state,
                           metadata: metadata)
 
+      block_value = block.call(new_state, metadata) if block_given?
       @current_state = new_state
-      true
+
+      block_value || true
     end
 
     def execute(phase, initial_state, new_state, transition)
@@ -217,8 +219,8 @@ module Statesmin
       callbacks.each { |cb| cb.call(@object, transition) }
     end
 
-    def transition_to(new_state, metadata = {})
-      self.transition_to!(new_state, metadata)
+    def transition_to(new_state, metadata = {}, &block)
+      self.transition_to!(new_state, metadata, &block)
     rescue TransitionFailedError, GuardFailedError
       false
     end

--- a/lib/statesmin/transition_helper.rb
+++ b/lib/statesmin/transition_helper.rb
@@ -17,10 +17,9 @@ module Statesmin
 
     def transition_to!(next_state, data = {})
       raise_transition_not_defined_error unless respond_to?(:transition)
-      guard_transitions_to_invalid_states!(next_state)
-      return_value = transition(next_state, data)
-      @state_machine = nil
-      return_value
+      state_machine.transition_to!(next_state, data) do
+        transition(next_state, data)
+      end
     end
 
     def transition_to(next_state, data = {})
@@ -37,13 +36,6 @@ module Statesmin
 
     def raise_transition_not_defined_error
       raise Statesmin::NotImplementedError.new('transition', self.class.name)
-    end
-
-    def guard_transitions_to_invalid_states!(next_state)
-      unless can_transition_to? next_state
-        raise Statesmin::TransitionFailedError,
-              "Cannot transition from '#{current_state}' to '#{next_state}'"
-      end
     end
   end
 end


### PR DESCRIPTION
Machine#transition_to(!) methods now take a block that conditionally executes if the next state is a valid transition. Simplifies TransitionHelper and its specs.
