### PR TITLE
Transition private

### DIFF
--- a/lib/statesmin/transition_helper.rb
+++ b/lib/statesmin/transition_helper.rb
@@ -16,7 +16,7 @@ module Statesmin
     end
 
     def transition_to!(next_state, data = {})
-      raise_transition_not_defined_error unless respond_to?(:transition, false)
+      raise_transition_not_defined_error unless respond_to?(:transition, true)
       state_machine.transition_to!(next_state, data) do
         transition(next_state, data)
       end

--- a/lib/statesmin/version.rb
+++ b/lib/statesmin/version.rb
@@ -1,3 +1,3 @@
 module Statesmin
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Redo of #8 correctly this time. Allow the `transition` method to be private or protected.
